### PR TITLE
Correctif de la commande dans le template des issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -5,12 +5,12 @@ labels: ["bug"]
 body:
   - type: markdown
     attributes:
-      value: "## **Description du problème**\nExplique clairement le problème rencontré."
+      value: "## **Description du problème**\nExpliquez clairement le problème rencontré."
   - type: textarea
     id: description_probleme
     attributes:
       label: "Description du problème"
-      description: "Explique clairement ce qui ne va pas."
+      description: "Expliquez clairement ce qui ne va pas."
       placeholder: "Décrivez le problème ici..."
     validations:
       required: true
@@ -29,7 +29,7 @@ body:
 
   - type: markdown
     attributes:
-      value: "## **Comportement attendu**\nDécris ce que tu attendais à la place."
+      value: "## **Comportement attendu**\nDécrivez ce que vous attendiez à la place."
   - type: textarea
     id: comportement_attendu
     attributes:
@@ -77,7 +77,6 @@ body:
       description: "Si vous avez modifié la configuration, veuillez fournir les détails ici."
       placeholder: "Décrivez les modifications apportées à la configuration..."
 
-
   - type: markdown
     attributes:
       value: "## **Impact du problème**\nCochez l'une des cases."
@@ -110,7 +109,26 @@ body:
 
   - type: markdown
     attributes:
-      value: "## **Informations Système**\n```bash\nnix-shell -p pciutils util-linux inxi --run \"echo -e '\\n--- Infos ---' ; inxi -M ; echo -e '\\n--- CPU ---' ; lscpu | grep -E 'Architecture|CPU op-mode|Vendor ID|Model name' | awk '{$1=$1; print}' ; echo -e '\\n--- GPU ---' ; lspci | grep -E 'VGA|3D' ; echo -e '\\n--- RAM ---'; df -h / ; echo -e '\\n--- Disque --- ' ; free -h\"\n```\nCollez les informations système ici :"
+      value: |
+        ## **Informations Système**
+
+        Exécutez la commande suivante pour collecter les informations système nécessaires :
+
+        ```bash
+        nix-shell -p pciutils util-linux inxi gawk --run "
+        echo -e '\n--- Infos ---'; \
+        inxi -M; \
+        echo -e '\n--- CPU ---'; \
+        lscpu | grep -E '(Architecture|CPU op-mode|Vendor ID|Model name|Mode\\(s\\) opératoire\\(s\\) des processeurs|Identifiant constructeur|Nom de modèle)' | awk '{print \$0}'; \
+        echo -e '\n--- GPU ---'; \
+        lspci | grep -E 'VGA|3D'; \
+        echo -e '\n--- Disque ---'; \
+        df -h; \
+        echo -e '\n--- RAM ---'; \
+        free -h"
+        ```
+        Collez les informations système ici :
+
   - type: textarea
     id: informations_systeme
     attributes:


### PR DESCRIPTION
Le template des issues inclut une commande nix-shell -p permettant d'obtenir des informations sur le matériel. 

En l'état cette commande ne récupère pas correctement les informations lorsque le système est en français. 
Ce pr corrige la commande et récupère correctement les infos indépendamment de si le système est en français ou en anglais. 

La formulation a été modifier : `tutoiement` -> `vouvoiement`