### PR TITLE
improve flake, workflow for test user configurations

### DIFF
--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -2,16 +2,13 @@ name: Build GLF-OS Configurations
 
 on:
   push:
-    branches:
-      - main
-      - dev
-    paths:
-      - '**/*.nix'  
+    branches: [main, dev]
+    paths: ['**/*.nix']
+
   pull_request:
-    branches:
-      - '**' 
-    paths:
-      - '**/*.nix'
+    branches: ['**'] 
+    paths: ['**/*.nix']
+
   workflow_dispatch:
 
 jobs:
@@ -25,7 +22,29 @@ jobs:
 
       - name: Build GLF
         run: nix run github:Mic92/nix-fast-build -- --no-nom  --skip-cached --systems 'x86_64-linux' -f .#nixosConfigurations.glf-installer.config.system.build.toplevel
+        continue-on-error: false
 
-      - name: Report Results
+  test-user-config:
+    name: Test User Configuration
+    runs-on: ubuntu-latest
+    needs: []
+    steps:
+      - uses: actions/checkout@v3
+      - uses: cachix/install-nix-action@v17
+      
+      - name: Build User Test Configuration
+        run: nix run github:Mic92/nix-fast-build -- --no-nom  --skip-cached --systems 'x86_64-linux' -f .#nixosConfigurations.user-test.config.system.build.toplevel
+
+  report:
+    name: Final Status
+    runs-on: ubuntu-latest
+    needs: [buildGLF-Configurations, test-user-config]
+    steps:
+      - name: Combine Results
         run: |
-          echo "✅ Build completed successfully."
+          echo "Build status:"
+          echo "- Installer: ${{ needs.buildGLF-Configurations.result }}"
+          echo "- Installer: ${{ contains(needs.*.result, 'success') && '✅' || '❌' }}"
+          echo "- User Config: ${{ needs.test-user-config.result }}"
+          echo "✅ Testing completed"
+        if: always()


### PR DESCRIPTION
Amélioration pour les actions, voir #145 

L'action `nix-build` peut maintenant : 
- Construire la configuration GLF 
- Construire la configuration utilisateur 

Ces deux tâches sont exécutées parallèlement. Si l'une des tâches échoue, l'autre continue. 

Le flocon a été modifié pour créer une nouvelle sortie dédiée aux tests de la configuration utilisateur.