### PR TITLE
Add support of lg4ff steering wheel, for linux-zen -> linux

### DIFF
--- a/modules/default/gaming.nix
+++ b/modules/default/gaming.nix
@@ -16,12 +16,16 @@
       mangohud
       wineWowPackages.staging
       winetricks
+
+      # Steering wheels
+      oversteer
+      linuxKernel.packages.linux_zen.new-lg4ff	# This one need to be manually updated for "stable" and "latest" kernels, because of kernel version on package name. No problem for currently used "zen" kernel
     ];
 
     environment.sessionVariables = {
       STEAM_EXTRA_COMPAT_TOOLS_PATHS = "\${HOME}/.steam/root/compatibilitytools.d";
       MANGOHUD_CONFIG = "control=mangohud,legacy_layout=0,horizontal,battery,time,time_format=%H\\:%M,gpu_stats,gpu_power,cpu_stats,ram,vram,fps,frametime=1,frame_timing=1,hud_no_margin,table_columns=14";
-    }; 
+    };
 
     services.udev.extraRules = ''
       # USB
@@ -33,7 +37,7 @@
     '';
 
     hardware.steam-hardware.enable = true;
-    
+
     programs.steam = {
       enable = true;
       package = pkgs.steam.override { extraEnv = { MANGOHUD = true; OBS_VKCAPTURE = true; }; };
@@ -41,7 +45,7 @@
       localNetworkGameTransfers.openFirewall = true;
       extraCompatPackages = with pkgs; [ proton-ge-bin ];
     };
-    
+
   };
 
 }

--- a/modules/default/gaming.nix
+++ b/modules/default/gaming.nix
@@ -19,7 +19,6 @@
 
       # Steering wheels
       oversteer
-      linuxKernel.packages.linux_zen.new-lg4ff	# This one need to be manually updated for "stable" and "latest" kernels, because of kernel version on package name. No problem for currently used "zen" kernel
     ];
 
     environment.sessionVariables = {
@@ -37,6 +36,7 @@
     '';
 
     hardware.steam-hardware.enable = true;
+    hardware.new-lg4ff.enable = true;  # Compatible only with the base NixOS kernel
 
     programs.steam = {
       enable = true;


### PR DESCRIPTION
Asked by cieltof via Vinceff [here](https://discord.com/channels/827209409607893023/1333375113948561459).

Added package oversteer and linuxKernel.packages.linux_zen.new-lg4ff.

Carrefull with linuxKernel.packages.linux_zen.new-lg4ff :
This one need to be manually updated for "stable" and "latest" kernels, because of kernel version on package name. No problem for currently used "zen" kernel

NO TESTED