### PR TITLE
fix path docs

### DIFF
--- a/docs/pages/documentation/Installation.md
+++ b/docs/pages/documentation/Installation.md
@@ -29,7 +29,7 @@ nav_order: 1
 	{: .info }
 	> L'hébergeur du lien vers l'iso a une limite de **100 téléchargements par heure**.
 
-- <img src="../../assets/images/computer.svg" style="width: 32px; height: 32px; vertical-align: middle;"> Un ordinateur répondant à la [configuration minimale](/pages/documentation/minimalConfiguration.html).
+- <img src="../../assets/images/computer.svg" style="width: 32px; height: 32px; vertical-align: middle;"> Un ordinateur répondant à la [configuration minimale](./minimalConfiguration.html).
 - <img src="../../assets/images/network.svg" style="width: 32px; height: 32px; vertical-align: middle;"> Une connexion internet.
 	
 ## <img src="../../assets/images/checksum.svg" style="width: 24px; height: 24px; vertical-align: middle;"> Vérification du Checksum (Optionnel mais recommandé)

--- a/docs/pages/documentation/installPackageFromNix.md
+++ b/docs/pages/documentation/installPackageFromNix.md
@@ -1,12 +1,12 @@
 ---
-title: Installer un paquet provenant de Nix
+title: Installer un paquet provenant de Nix sans flatpak
 layout: default
 parent: Documentation
 ---
 
-# Comment installer des paquets nix sans flatpak 
+# Comment installer un paquet nix sans flatpak 
 
-Nous vous conseillons de lire la page [configuration personnalisée](/pages/documentation/customconfiguration.html) et nous vous rappelons que cet usage est strictement réservé à ceux qui savent ce qu'ils font.
+Nous vous conseillons de lire la page concernant les [configurations personnalisées](./customconfiguration.html) et nous vous rappelons que cet usage est strictement réservé à ceux qui savent ce qu'ils font.
 GLFOS ne supporte pas les modifications de configurations réalisées par vos propre soins.
 
 Cette étape n'est qu'à faire une seule fois. 
@@ -51,18 +51,3 @@ Enfin, appliquez la configuration avec :
 ```bash
 glf-switch
 ```
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
Le PR corrige plusieurs liens morts dans la documentation. 

La raison : Les chemins entre la documentation locale et celle publiée via github est différente.
Pour s'épargner trop de complexité et avoir des résultats identique entre les tests locaux et la version publiée, on a besoin d'utiliser des chemins qui partent du répertoire courant au lieu d'un chemin qui commencent par root (**/**).
