### PR TITLE
fix actionDocs

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -35,9 +35,12 @@ jobs:
         with:
           ruby-version: '3.3'
           bundler-cache: true
+          bundler: '2.5.9'
 
       - name: Install dependencies
-        run: bundle install
+        run: |
+          bundle config set path 'vendor/bundle'
+          bundle install
         working-directory: docs
 
       - name: Setup GitHub Pages


### PR DESCRIPTION
PR permettant de corriger l'action pour construire et déployer la documentation. 
Maintenant, le comportement de `nix develop` et de l'action devraient être identique. 

Nous n'aurons que dans le pire des cas à mettre à jour manuellement l'action lors de changement de versions. 