### PR TITLE
Mise à jours des flocons

### DIFF
--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -25,7 +25,7 @@ jobs:
         uses: cachix/install-nix-action@v17
 
       - name: Build GLF
-        run: nix run github:Mic92/nix-fast-build -- --no-nom  --skip-cached --systems 'x86_64-linux' -f .#nixosConfigurations.glf-installer.config.system.build.toplevel
+        run: nix build .#nixosConfigurations.glf-installer.config.system.build.toplevel
         continue-on-error: false
 
   test-user-config:
@@ -37,7 +37,7 @@ jobs:
       - uses: cachix/install-nix-action@v17
       
       - name: Build User Test Configuration
-        run: nix run github:Mic92/nix-fast-build -- --no-nom  --skip-cached --systems 'x86_64-linux' -f .#nixosConfigurations.user-test.config.system.build.toplevel
+        run: nix build .#nixosConfigurations.user-test.config.system.build.toplevel
 
   report:
     name: Final Status

--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -3,11 +3,15 @@ name: Build GLF-OS Configurations
 on:
   push:
     branches: [main, dev]
-    paths: ['**/*.nix']
+    paths:
+      - '**/*.nix'
+      - '**/*.lock'
 
   pull_request:
     branches: ['**'] 
-    paths: ['**/*.nix']
+    paths:
+      - '**/*.nix'
+      - '**/*.lock'
 
   workflow_dispatch:
 

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1737569578,
-        "narHash": "sha256-6qY0pk2QmUtBT9Mywdvif0i/CLVgpCjMUn6g9vB+f3M=",
+        "lastModified": 1738023785,
+        "narHash": "sha256-BPHmb3fUwdHkonHyHi1+x89eXB3kA1jffIpwPVJIVys=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "47addd76727f42d351590c905d9d1905ca895b82",
+        "rev": "2b4230bf03deb33103947e2528cac2ed516c5c89",
         "type": "github"
       },
       "original": {

--- a/iso-cfg/flake.lock
+++ b/iso-cfg/flake.lock
@@ -6,27 +6,27 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1737724085,
-        "narHash": "sha256-T4w9cffpISb31WttBWQAIXHJ3Jm8AzJ4C58yWyQXO5w=",
-        "owner": "CORAAL",
-        "repo": "Nixos-by-GLF",
-        "rev": "edbc927b11a57cab1d7320d4a3ef5484432e3935",
+        "lastModified": 1738225107,
+        "narHash": "sha256-Q+3KuO29Ry4gDBv4LbugKRQX9Y3XaTs6pm1OMRQ8+pA=",
+        "owner": "Gaming-Linux-FR",
+        "repo": "GLF-OS",
+        "rev": "a9edce5ab6ef8cce978e9b5e3184b7cd9791f907",
         "type": "github"
       },
       "original": {
-        "owner": "CORAAL",
-        "ref": "coraal_flakeInit",
-        "repo": "Nixos-by-GLF",
+        "owner": "Gaming-Linux-FR",
+        "ref": "main",
+        "repo": "GLF-OS",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1736549401,
-        "narHash": "sha256-ibkQrMHxF/7TqAYcQE+tOnIsSEzXmMegzyBWza6uHKM=",
+        "lastModified": 1737569578,
+        "narHash": "sha256-6qY0pk2QmUtBT9Mywdvif0i/CLVgpCjMUn6g9vB+f3M=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1dab772dd4a68a7bba5d9460685547ff8e17d899",
+        "rev": "47addd76727f42d351590c905d9d1905ca895b82",
         "type": "github"
       },
       "original": {
@@ -38,11 +38,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1737569578,
-        "narHash": "sha256-6qY0pk2QmUtBT9Mywdvif0i/CLVgpCjMUn6g9vB+f3M=",
+        "lastModified": 1738023785,
+        "narHash": "sha256-BPHmb3fUwdHkonHyHi1+x89eXB3kA1jffIpwPVJIVys=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "47addd76727f42d351590c905d9d1905ca895b82",
+        "rev": "2b4230bf03deb33103947e2528cac2ed516c5c89",
         "type": "github"
       },
       "original": {

--- a/modules/default/gnome.nix
+++ b/modules/default/gnome.nix
@@ -89,14 +89,8 @@
       ];
 
       etc = {
-        "wallpapers/glf/white.jpg".source = pkgs.fetchurl {
-          url = "https://github.com/CORAAL/Nixos-by-GLF/raw/coraal_flakeInit/assets/wallpaper/white.jpg";
-          sha256 = "sha256-XTy91wEVIKZc7A39ruOc1Beg/KG2YUuOXjB2B0oDdTY=";
-        };
-        "wallpapers/glf/dark.jpg".source = pkgs.fetchurl {
-          url = "https://github.com/CORAAL/Nixos-by-GLF/raw/coraal_flakeInit/assets/wallpaper/dark.jpg";
-          sha256 = "sha256-zkybmVAcclbg92u16yZ6QhFCvaXeGtYs3yCxfJWx390=";
-        };
+        "wallpapers/glf/white.jpg".source = ../../assets/wallpaper/white.jpg;
+        "wallpapers/glf/dark.jpg".source = ../../assets/wallpaper/dark.jpg;
       };
     };
 


### PR DESCRIPTION
- Mise à jour des flocons
- Passage de `nix-fast-build` à `nix build` pour les workflows de tests (un peu plus lent, mais les logs sont plus faciles à lire) 
- Correction de coquilles liée à la manière de récupérer les wallpapers (auparavant via une url, maintenant fournis par le module glf)