### PR TITLE
Ajout de l'extension "Blur my shell"

### DIFF
--- a/modules/default/gnome.nix
+++ b/modules/default/gnome.nix
@@ -61,6 +61,7 @@
         gnomeExtensions.gsconnect
         gnomeExtensions.appindicator
         gnomeExtensions.dash-to-dock
+        gnomeExtensions.blur-my-shell
 
       ];
 
@@ -139,6 +140,7 @@
                 "gsconnect@andyholmes.github.io"
                 "appindicatorsupport@rgcjonas.gmail.com"
                 "dash-to-dock@micxgx.gmail.com"
+                "blur-my-shell@aunetx"
               ];
               favorite-apps = [
                 "firefox.desktop"


### PR DESCRIPTION
Pour améliorer l'apparence de gnome avec quelques effets de flou (dans la top bar et dans l'overview)