### PR TITLE
Ajout de l'option glf.compressionExtraTools.enable

### DIFF
--- a/modules/default/compressionExtraTools.nix
+++ b/modules/default/compressionExtraTools.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
+
+{
+
+  options.glf.compressionExtraTools.enable = lib.mkOption {
+    description = "Add other compression tools";
+    type = lib.types.bool;
+    default = true;
+  };
+
+  config = lib.mkIf config.glf.compressionExtraTools.enable {
+
+    environment.systemPackages = with pkgs; [
+      arj
+      brotli
+      bzip2
+      cpio
+      gnutar
+      gzip
+      lha
+      libarchive
+      lrzip
+      lz4
+      lzop
+      p7zip
+      pbzip2
+      pigz
+      pixz
+      unrar
+    ];
+
+  };
+
+}

--- a/modules/default/default.nix
+++ b/modules/default/default.nix
@@ -17,6 +17,7 @@
     ./update.nix
     ./version.nix
     ./standBy.nix
+    ./compressionExtraTools.nix
   ];
 
 }

--- a/modules/default/packages.nix
+++ b/modules/default/packages.nix
@@ -45,22 +45,6 @@
       transmission_4-gtk
 
       # Compression
-      arj
-      brotli
-      bzip2
-      cpio
-      gnutar
-      gzip
-      lha
-      libarchive
-      lrzip
-      lz4
-      lzop
-      p7zip
-      pbzip2
-      pigz
-      pixz
-      unrar
       unzip
       xz
       zip


### PR DESCRIPTION
J'ai ajouter un peu de séparation entre les paquets qui sont installé par défaut avec GLF-OS et les autres outils de compressions (pour surtout donner la possibilité a l'utilisateur final de désactiver l'option s'il n'a pas forcément besoin de bzip2 ou gzip par exemple)