### PR TITLE
GLFfetch: remove unused symlink and add metadata to nix expression

### DIFF
--- a/pkgs/GLFfetch/default.nix
+++ b/pkgs/GLFfetch/default.nix
@@ -60,7 +60,12 @@ stdenvNoCC.mkDerivation rec {
     makeWrapper ${fastfetch}/bin/fastfetch $out/bin/GLFfetch \
       --add-flags "--config $assets/share/${pname}/challenge.jsonc" \
       --prefix PATH : ${coreutils}/bin:${gawk}/bin
-
-    ln -s $out/bin/GLFfetch $out/bin/GLFfetch-nixos
   '';
+
+  meta = {
+    description = "A another 'fetch', but with custom configuration (build with fastfetch)";
+    homepage = "https://github.com/Gaming-Linux-FR/GLFfetch";
+    license = lib.licenses.mit;
+    mainProgram = "GLFfetch";
+  };
 }

--- a/pkgs/GLFfetch/default.nix
+++ b/pkgs/GLFfetch/default.nix
@@ -63,7 +63,7 @@ stdenvNoCC.mkDerivation rec {
   '';
 
   meta = {
-    description = "A another 'fetch', but with custom configuration (build with fastfetch)";
+    description = "A customized neofetch config file built for the GLF Linux challenges (a fork of GLFfetch to support nix)";
     homepage = "https://github.com/Gaming-Linux-FR/GLFfetch";
     license = lib.licenses.mit;
     mainProgram = "GLFfetch";


### PR DESCRIPTION
I remove the unused symlink `GLFfetch-nixos` from GLFfetch and added metadata to the nix expression (meta.mainProgram is used when the expression is called by nix run)

- **GLFfetch: remove unused symlink**
- **GLFfetch: change description**
