### PR TITLE
Fix build error caused by hplip plugin fetch

### DIFF
--- a/modules/default/printing.nix
+++ b/modules/default/printing.nix
@@ -16,6 +16,15 @@
     let
       allUsers = builtins.attrNames config.users.users;
       normalUsers = builtins.filter (user: config.users.users.${user}.isNormalUser) allUsers;
+
+      # contexte: https://github.com/NixOS/nixpkgs/issues/391727
+      hplipPluginMirror = "https://www.openprinting.org/download/printdriver/auxfiles/HP/plugins";
+      hplipWithPluginFix = pkgs.hplipWithPlugin.overrideAttrs (prev: {
+        plugin = pkgs.fetchurl {
+          url = "${hplipPluginMirror}/${prev.pname}-${prev.version}-plugin.run";
+          hash = "sha256-Hzxr3SVmGoouGBU2VdbwbwKMHZwwjWnI7P13Z6LQxao=";
+        };
+      });
     in
     {
       services = {
@@ -32,8 +41,7 @@
             epkowa
             gutenprint
             gutenprintBin
-            hplip
-            hplipWithPlugin
+            hplipWithPluginFix
             samsung-unified-linux-driver
             splix
           ];


### PR DESCRIPTION
Actuellement `hplib` ne peut plus être build à cause d'un lien qui retourne 403. Une pr est en cours sur nixpkgs, mais le merge peut prendre du temps. De plus, ce fixe utilise le mirror proposé au lieu de contourner la restriction avec les options curl.

- https://github.com/NixOS/nixpkgs/issues/391727

```
┏━ Dependency Graph:
┃                ┌─ ✔ unit-dbus.service 
┃             ┌─ ✔ user-units 
┃             ├─ ✔ etc-pam-environment 
┃             ├─ ✔ hwdb.bin
┃             │  ┌─ ✔ set-environment 
┃             ├─ ✔ etc-profile 
┃             │  ┌─ ✔ unit-polkit.service
┃             │  ├─ ✔ unit-dbus.service 
┃             │  │           ┌─ ✔ cups-progs 
┃             │  │        ┌─ ✔ cups-files.conf 
┃             │  │     ┌─ ✔ cups-progs 
┃             │  │  ┌─ ✔ unit-script-cups-pre-start 
┃             │  ├─ ✔ unit-cups.service 
┃             │  │        ┌─ ✔ hplip-3.24.4
┃             │  │     ┌─ ✔ udev-rules
┃             │  │  ┌─ ✔ X-Restart-Triggers-systemd-udevd 
┃             │  ├─ ✔ unit-systemd-udevd.service 
┃             ├─ ✔ system-units
┃          ┌─ ✔ etc 
┃       ┌─ ✔ nixos-system-GLF-OS-25.05.20250318.b6eaf97 
┃    ┌─ ✔ closure-info 
┃ ┌─ ✔ run-nixos-vm 
┃ ✔ nixos-vm 
┣━━━ Builds          
┗━ ∑ ⏵ 0 │ ✔ 29 │ ⏸ 0 │ Finished at 14:25:19 after 1m56s
```