### PR TITLE
Configs pour l'ajout de DE / Support du pilote propriétaire nvidia / Ajout de nix-disk-manager

### DIFF
--- a/iso-cfg/configuration.nix
+++ b/iso-cfg/configuration.nix
@@ -4,6 +4,15 @@
 
   glf.autoUpgrade = lib.mkForce false;
   glf.nvidia_config.enable = true;
+  system.nixos.tags = lib.mkDefault [ "Alpha.v2" ];
+  specialisation = {
+    nvidia_proprietary_driver = {
+      configuration = {
+        system.nixos.tags = lib.mkForce [ "nvidia_proprietary_driver-Alpha.v2" ];
+        glf.nvidia_config.type = "proprietary";
+      };
+    };
+  };
 
   i18n.defaultLocale = "fr_FR.UTF-8";
 

--- a/iso-cfg/configuration.nix
+++ b/iso-cfg/configuration.nix
@@ -9,10 +9,8 @@
 
   console.keyMap = "fr";
   services.xserver = {
-    enable = true;
     xkb.layout = "fr";
     xkb.variant = "";
-    excludePackages = [ pkgs.xterm ];
   };
 
   users.users.nixos = {

--- a/modules/default/default.nix
+++ b/modules/default/default.nix
@@ -18,6 +18,7 @@
     ./version.nix
     ./standBy.nix
     ./GLFfetch.nix
+    ./nix-disk-manager.nix
   ];
 
 }

--- a/modules/default/default.nix
+++ b/modules/default/default.nix
@@ -4,10 +4,10 @@
     ./debug.nix
     ./aliases.nix
     ./boot.nix
+    ./environment.nix
     ./firefox.nix
     ./fstrim.nix
     ./gaming.nix
-    ./gnome.nix
     ./nh.nix
     ./nvidia.nix
     ./packages.nix

--- a/modules/default/environment.nix
+++ b/modules/default/environment.nix
@@ -1,0 +1,45 @@
+{ config, lib, pkgs, ... }:
+with lib;
+let
+  cfg = config.glf.environment;
+in
+{
+  # declare option
+  options.glf.environment = {
+    enable = mkOption {
+      type = with types; bool;
+      default = true;
+      description = "Enable desktop environment";
+    };
+    type = lib.mkOption {
+      description = "Desktop environment selection";
+      type = with types; enum [ "gnome" "plasma" "xfce" "cinnamon" "mate" ];
+      default = "gnome";
+    };
+  };
+
+  # Import desktop environment configurations
+  imports = [
+    ./environments/gnome.nix
+    ./environments/plasma.nix
+    ./environments/xfce.nix
+    ./environments/cinnamon.nix
+    ./environments/mate.nix
+  ];
+
+  # Wallpapers
+  config = mkIf cfg.enable {
+    services.xserver = {
+      enable = true;
+      excludePackages = [ pkgs.xterm ];
+    };
+    environment = {
+      etc = {
+         "skel/.background-image".source = ../../assets/wallpaper/white.jpg;
+         "wallpapers/glf/white.jpg".source = ../../assets/wallpaper/white.jpg;
+         "wallpapers/glf/dark.jpg".source = ../../assets/wallpaper/dark.jpg;
+      };
+    };
+  };
+
+}

--- a/modules/default/environments/cinnamon.nix
+++ b/modules/default/environments/cinnamon.nix
@@ -1,0 +1,77 @@
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
+
+{
+
+  config = lib.mkIf (config.glf.environment.type == "cinnamon") {
+
+    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    # Activation de Cinnamon
+    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    services = {
+      displayManager.defaultSession = "cinnamon";
+      power-profiles-daemon.enable = true;
+      xserver = {
+        displayManager.lightdm.enable = true;
+        displayManager.lightdm.background = "/etc/wallpapers/glf/white.jpg";
+        displayManager.lightdm.greeters.slick = {
+          enable = true;
+          iconTheme.name = "Tela-circle";
+          theme.name = "adw-gtk3";
+        };
+        desktopManager.cinnamon.enable = true;
+      };
+    };
+    
+    xdg.portal = {
+      enable = true;
+      extraPortals = [ pkgs.xdg-desktop-portal-gtk ];
+      xdgOpenUsePortal = true;
+    };
+
+    documentation.nixos.enable = false;
+
+    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    # Packages système
+    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    environment = {
+      systemPackages = with pkgs; [
+
+        # Theme
+        adw-gtk3
+        graphite-gtk-theme
+        tela-circle-icon-theme
+      ];
+    };
+
+    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    # Paramètres Cinnamon
+    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    programs.dconf = {
+      enable = true;
+      profiles.user.databases = [
+        {
+          settings = {
+            "org/cinnamon/desktop/interface" = {
+              cursor-theme = "Adwaita";
+              gtk-theme = "adw-gtk3";
+              icon-theme = "Tela-circle";
+            };
+
+            "org/cinnamon/desktop/background" = {
+              color-shading-type = "solid";
+              picture-options = "zoom";
+              picture-uri = "file:///etc/wallpapers/glf/white.jpg";
+              picture-uri-dark = "file:///etc/wallpapers/glf/dark.jpg";
+            };
+          };
+        }
+      ];
+    };
+  };
+
+}

--- a/modules/default/environments/gnome.nix
+++ b/modules/default/environments/gnome.nix
@@ -7,33 +7,37 @@
 
 {
 
-  options.glf.gnome.enable = lib.mkOption {
-    description = "Enable GLF Gnome configurations";
-    type = lib.types.bool;
-    default = true;
-  };
-
-  config = lib.mkIf config.glf.gnome.enable {
+  config = lib.mkIf (config.glf.environment.type == "gnome") {
 
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    # Activation de GNOME
+    # Activation de Gnome
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     services = {
+      displayManager.defaultSession = "gnome";
+      power-profiles-daemon.enable = true;
       udev.packages = [ pkgs.gnome-settings-daemon ];
       xserver = {
         displayManager.gdm.enable = lib.mkDefault true;
         desktopManager.gnome = {
           enable = lib.mkDefault true;
-
           # Activation du Fractional Scaling
           extraGSettingsOverridePackages = [ pkgs.mutter ];
           extraGSettingsOverrides = ''
-              [org.gnome.mutter]
+            [org.gnome.mutter]
             experimental-features=['scale-monitor-framebuffer']
           '';
         };
       };
     };
+
+    xdg.portal = {
+      enable = true;
+      extraPortals = [ pkgs.xdg-desktop-portal-gnome ];
+      xdgOpenUsePortal = true;
+    };
+
+    systemd.services."getty@tty1".enable = false;
+    systemd.services."autovt@tty1".enable = false;
 
     documentation.nixos.enable = false;
 
@@ -48,12 +52,12 @@
     environment = {
       systemPackages = with pkgs; [
 
-        # theme
+        # Theme
         adw-gtk3
         graphite-gtk-theme
         tela-circle-icon-theme
 
-        # gnome
+        # Gnome
         gnome-tweaks
 
         # Extension
@@ -61,7 +65,6 @@
         gnomeExtensions.gsconnect
         gnomeExtensions.appindicator
         gnomeExtensions.dash-to-dock
-
       ];
 
       # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -87,15 +90,10 @@
         gnome-packagekit
         gnome-font-viewer
       ];
-
-      etc = {
-        "wallpapers/glf/white.jpg".source = ../../assets/wallpaper/white.jpg;
-        "wallpapers/glf/dark.jpg".source = ../../assets/wallpaper/dark.jpg;
-      };
     };
 
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    # Paramètres GNOME
+    # Paramètres Gnome
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     programs.dconf = {
       enable = true;
@@ -118,8 +116,8 @@
             "org/gnome/desktop/background" = {
               color-shading-type = "solid";
               picture-options = "zoom";
-              picture-uri = "file:///${config.environment.etc."wallpapers/glf/white.jpg".source}";
-              picture-uri-dark = "file:///${config.environment.etc."wallpapers/glf/dark.jpg".source}";
+              picture-uri = "file:///etc/wallpapers/glf/white.jpg";
+              picture-uri-dark = "file:///etc/wallpapers/glf/dark.jpg";
             };
 
             "org/gnome/desktop/peripherals/touchpad" = {
@@ -146,7 +144,6 @@
                 "net.lutris.Lutris.desktop"
                 "com.heroicgameslauncher.hgl.desktop"
                 "discord.desktop"
-                "thunderbird.desktop"
                 "org.gnome.Nautilus.desktop"
                 "org.dupot.easyflatpak.desktop"
                 "org.gnome.Calendar.desktop"

--- a/modules/default/environments/mate.nix
+++ b/modules/default/environments/mate.nix
@@ -1,0 +1,78 @@
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
+
+{
+
+  config = lib.mkIf (config.glf.environment.type == "mate") {
+
+    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    # Activation de Mate
+    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    services = {
+      displayManager.defaultSession = "mate";
+      power-profiles-daemon.enable = true;
+      xserver = {
+        displayManager.lightdm.enable = true;
+        displayManager.lightdm.background = "/etc/wallpapers/glf/white.jpg";
+        displayManager.lightdm.greeters.slick = {
+          enable = true;
+          iconTheme.name = "Tela-circle";
+          theme.name = "adw-gtk3";
+        };
+        desktopManager.mate.enable = true;
+      };
+    };
+    
+    xdg.portal = {
+      enable = true;
+      extraPortals = [ pkgs.xdg-desktop-portal-gtk ];
+      xdgOpenUsePortal = true;
+    };
+
+    documentation.nixos.enable = false;
+
+    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    # Packages système
+    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    environment = {
+      systemPackages = with pkgs; [
+
+        # Theme
+        adw-gtk3
+        graphite-gtk-theme
+        tela-circle-icon-theme
+
+        # Mate
+        networkmanagerapplet
+      ];
+    };
+
+    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    # Paramètres Mate
+    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    programs.dconf = {
+      enable = true;
+      profiles.user.databases = [
+        {
+          settings = {
+            "org/mate/desktop/interface" = {
+              gtk-theme = "adw-gtk3";
+              icon-theme = "Tela-circle";
+            };
+
+            "org/mate/desktop/background" = {
+              color-shading-type = "solid";
+              picture-options = "zoom";
+              picture-filename = "file:///etc/wallpapers/glf/white.jpg";
+            };
+          };
+        }
+      ];
+    };
+  };
+
+}

--- a/modules/default/environments/plasma.nix
+++ b/modules/default/environments/plasma.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
+
+{
+
+  config = lib.mkIf (config.glf.environment.type == "plasma") {
+
+    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    # Activation de Plasma
+    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    services = {
+      displayManager.defaultSession = "plasma";
+      xserver = {
+        displayManager.sddm = {
+          enable = true;
+          theme = "breeze";
+        };
+        desktopManager.plasma6.enable = true;
+      };
+    };
+
+    xdg.portal = {
+      enable = true;
+      extraPortals = [ pkgs.xdg-desktop-portal-kde ];
+      xdgOpenUsePortal = true;
+    };
+
+    systemd.services."getty@tty1".enable = false;
+    systemd.services."autovt@tty1".enable = false;
+
+    documentation.nixos.enable = false;
+
+    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    # Packages système
+    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    programs.kdeconnect.enable = true;
+
+    environment = {
+      systemPackages = with pkgs; [
+        writeTextDir "share/sddm/themes/breeze/theme.conf.user" ''
+          [General]
+          background = ${config.environment.etc."wallpapers/glf/white.jpg".source}
+        ''
+      ];
+    };
+  };
+
+}

--- a/modules/default/environments/xfce.nix
+++ b/modules/default/environments/xfce.nix
@@ -1,0 +1,70 @@
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
+
+{
+
+  config = lib.mkIf (config.glf.environment.type == "xfce") {
+
+    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    # Activation de Xfce
+    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    services = {
+      displayManager.defaultSession = "xfce";
+      xserver = {
+        displayManager.lightdm.enable = true;
+        displayManager.lightdm.background = "/etc/wallpapers/glf/white.jpg";
+        displayManager.lightdm.greeters.slick = {
+          enable = true;
+          iconTheme.name = "Tela-circle";
+          theme.name = "adw-gtk3";
+        };
+        desktopManager.xfce.enable = true;
+      };
+    };
+
+    xdg.portal = {
+      enable = true;
+      extraPortals = [ pkgs.xdg-desktop-portal-gtk ];
+      xdgOpenUsePortal = true;
+    };
+
+    documentation.nixos.enable = false;
+
+    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    # Packages système
+    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    environment = {
+      systemPackages = with pkgs; [
+
+        # Theme
+        adw-gtk3
+        graphite-gtk-theme
+        tela-circle-icon-theme
+
+        # Xfce
+        xfce.xfce4-pulseaudio-plugin
+      ];
+      xfce.excludePackages = with pkgs; [
+        xfce.xfce4-appfinder
+        xfce.xfce4-taskmanager
+      ];
+    };
+
+    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    # Paramètres Xfce
+    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    programs.thunar = {
+      enable = true;
+      plugins = with pkgs.xfce; [
+        thunar-archive-plugin
+        thunar-media-tags-plugin
+        thunar-volman
+      ];
+    };
+  };
+
+}

--- a/modules/default/nix-disk-manager.nix
+++ b/modules/default/nix-disk-manager.nix
@@ -1,0 +1,28 @@
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
+
+let
+  ### Place custom pkgs here
+  nix-disk-manager = pkgs.callPackage ../../pkgs/nix-disk-manager {};
+in
+
+{
+
+  options.glf.packages.nix-disk-manager.enable = lib.mkOption {
+    description = "Enable GLF disk manager";
+    type = lib.types.bool;
+    default = true;
+  };
+
+  config = lib.mkIf config.glf.packages.nix-disk-manager.enable {
+    environment.systemPackages = with pkgs; [
+      nix-disk-manager
+    ];
+  };
+
+}
+

--- a/modules/default/nvidia.nix
+++ b/modules/default/nvidia.nix
@@ -11,6 +11,11 @@ in
       default = false;
       description = "Enable nvidia support";
     };
+    type = mkOption {
+      type = with types; enum [ "opensource" "proprietary" ];
+      default = "opensource";
+      description = "Select the nvidia driver version to use";
+    };
     laptop = mkOption {
       type = with types; bool;
       default = false;
@@ -32,14 +37,21 @@ in
 
   # nvidia configuration
   config = mkIf cfg.enable {
-    services.xserver.videoDrivers = [ "nvidia" ];
+    services.xserver.videoDrivers = [ "nvidia" "modesetting" "fbdev" ];
+    boot.blacklistedKernelModules = [ "nouveau" ];
 
     hardware.nvidia = {
       package = config.boot.kernelPackages.nvidiaPackages.latest;
-      open = true;
+
+      open =
+        if cfg.type == "opensource" then
+          true
+        else
+          false;
+
+      modesetting.enable = true;
 
       nvidiaSettings = true;
-      modesetting.enable = true;
 
       prime = {
         intelBusId = optionalAttrs (cfg.intelBusId != null) cfg.intelBusId;

--- a/patches/calamares-nixos-extensions/config/modules/packagechooser.conf
+++ b/patches/calamares-nixos-extensions/config/modules/packagechooser.conf
@@ -20,8 +20,36 @@ default: gnome
 items:
     - id: gnome
       packages: [ gnome ]
-      name: GNOME
+      name: Gnome
       description: "<html>
                     <p>Gnome est un environnement de bureau qui vise la simplicité en étant épuré et vous accompagnant pour avoir un environnement de travail qui vous permet de finir les choses. Gnome est un choix populaire et très apprécié dans la communauté de GLF-OS.</p>
                     </html>"
       screenshot: "/run/current-system/sw/share/calamares/images/gnome.png"
+    - id: plasma
+      packages: [ plasma ]
+      name: Plasma
+      description: "<html>
+                    <p>Plasma est un environnement de bureau qui ...</p>
+                    </html>"
+      screenshot: "/run/current-system/sw/share/calamares/images/plasma6.png"
+    - id: xfce
+      packages: [ xfce ]
+      name: Xfce
+      description: "<html>
+                    <p>Xfce est un environnement de bureau qui ...</p>
+                    </html>"
+      screenshot: "/run/current-system/sw/share/calamares/images/xfce.png"
+    - id: cinnamon
+      packages: [ cinnamon ]
+      name: Cinnamon
+      description: "<html>
+                    <p>Cinnamon est un environnement de bureau qui ...</p>
+                    </html>"
+      screenshot: "/run/current-system/sw/share/calamares/images/cinnamon.png"
+    - id: mate
+      packages: [ mate ]
+      name: Mate
+      description: "<html>
+                    <p>Mate est un environnement de bureau qui ...</p>
+                    </html>"
+      screenshot: "/run/current-system/sw/share/calamares/images/mate.png"

--- a/patches/calamares-nixos-extensions/modules/nixos/main.py
+++ b/patches/calamares-nixos-extensions/modules/nixos/main.py
@@ -112,18 +112,6 @@ cfglocaleextra = """  i18n.extraLocaleSettings = {
 
 """
 
-cfggnome = """  # Enable the X11 windowing system.
-  services.xserver.enable = true;
- 
-  services.xserver.excludePackages = [ pkgs.xterm ];
-  
-
-  # Enable the GNOME Desktop Environment.
-  services.xserver.displayManager.gdm.enable = true;
-  services.xserver.desktopManager.gnome.enable = true;
-  
-"""
-
 cfgkeymap = """  # Configure keymap in X11
   services.xserver.xkb = {
     layout = "@@kblayout@@";
@@ -148,12 +136,6 @@ cfgusers = """  # Define a user account. Don't forget to set a password with ‘
 cfgautologin = """  # Enable automatic login for the user.
   services.xserver.displayManager.autoLogin.enable = true;
   services.xserver.displayManager.autoLogin.user = "@@username@@";
-
-"""
-
-cfgautologingdm = """  # Workaround for GNOME autologin: https://github.com/NixOS/nixpkgs/issues/103746#issuecomment-945091229
-  systemd.services."getty@tty1".enable = false;
-  systemd.services."autovt@tty1".enable = false;
 
 """
 
@@ -288,6 +270,14 @@ def run():
     cfg = cfghead
     gs = libcalamares.globalstorage
     variables = dict()
+
+    # Select desktop environment
+    cfg += """  glf.environment = {
+    enable = true;
+    type = """ + '"' + gs.value("packagechooser_packagechooser") + '";' + """
+  };
+
+"""
 
     # Nvidia support
     vga_devices = get_vga_devices()
@@ -478,10 +468,6 @@ def run():
             for conf in localeconf:
                 catenate(variables, conf, localeconf.get(conf).split("/")[0])
 
-    # Choose desktop environment
-    if gs.value("packagechooser_packagechooser") == "gnome":
-        cfg += cfggnome
-
     # Keyboard layout settings
     if (
         gs.value("keyboardLayout") is not None
@@ -566,8 +552,6 @@ def run():
             and gs.value("packagechooser_packagechooser") != ""
         ):
             cfg += cfgautologin
-            if gs.value("packagechooser_packagechooser") == "gnome":
-                cfg += cfgautologingdm
         elif gs.value("autoLoginUser") is not None:
             cfg += cfgautologintty
 

--- a/pkgs/nix-disk-manager/default.nix
+++ b/pkgs/nix-disk-manager/default.nix
@@ -1,0 +1,13 @@
+{ pkgs }:
+pkgs.flutter.buildFlutterApplication rec {
+  pname = "nix-disk-manager";
+  version = "1.3.1";
+  src = pkgs.fetchgit {
+    url = "https://codeberg.org/imikado/nix-disk-manager.git";
+    tag = "${version}";
+    sha256 = "sha256-JNQUxZdZ/paQb0XdwHe7kzxFQsnz167+FjFNEpq7Lp0=";
+  };
+  autoPubspecLock = "${src}/pubspec.lock";
+  buildInputs = with pkgs; [ flutter dart zlib gtk3 pkg-config libtool libGL ];
+}
+


### PR DESCRIPTION
Bonjour à tous,

Félicitations pour la publication de l'Alpha GLF-OS !

J'ai un peu expérimenté avec la source et je vous propose ce PR en 3 parties:

- "[Add DE selection configs](https://github.com/Gaming-Linux-FR/GLF-OS/commit/3ec9cab51be045980e332ecb2a29f5fd7737797d)": Un schéma de configs pour l'ajout d'autres DE (Plasma, Cinnamon, Xfce et Mate) avec le support associé dans l'installeur calamares. (les configs fonctionnent mais il reste du travail en termes de personalisation).
- "[Add nvidia proprietary driver support and related specialisation](https://github.com/Gaming-Linux-FR/GLF-OS/commit/c51536ee90daee1ab88ca092ece4364c9670f939)": Ajoute le support du pilote propriétaire nvidia via une spécialisation dans l'iso (entrée grub supplémentaire) qui permet de booter avec ce pilote. Dans ce cas, l'installeur applique également le pilote propriétaire nvidia au système installé.
- "[Add nix-disk-manager package](https://github.com/Gaming-Linux-FR/GLF-OS/commit/6723cc45287737048ffe072a877bdf4b12f18854)": Ajout de nix-disk-manager.

N'hésitez pas à clôturer ce PR si ça ne correspond pas à la vision pour votre futur OS.