### PR TITLE
Configs pour l'ajout de DE / Support du pilote propriétaire nvidia / Ajout de nix-disk-manager v2

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -60,8 +60,9 @@
               ];
             }
             (
-              { config, ... }:
+              { config, lib, pkgs, ... }:
               {
+                image.baseName = lib.mkForce "${config.isoImage.volumeID}-${pkgs.stdenv.hostPlatform.system}";
                 isoImage = {
                   volumeID = "GLF-OS-ALPHA-OMNISLASH_2"; #Nom à changer en fonction de la nomination GLF OS
                   includeSystemBuildDependencies = false;

--- a/iso-cfg/configuration.nix
+++ b/iso-cfg/configuration.nix
@@ -1,14 +1,13 @@
-{ pkgs, lib, ... }:
+{ config, lib, pkgs, ... }:
 
 {
 
   glf.autoUpgrade = lib.mkForce false;
   glf.nvidia_config.enable = true;
-  system.nixos.tags = lib.mkDefault [ "Alpha.v2" ];
   specialisation = {
     nvidia_proprietary_driver = {
       configuration = {
-        system.nixos.tags = lib.mkForce [ "nvidia_proprietary_driver-Alpha.v2" ];
+        system.nixos.tags = lib.mkForce [ "nvidia_proprietary_driver" ];
         glf.nvidia_config.type = "proprietary";
       };
     };

--- a/iso-cfg/flake.nix
+++ b/iso-cfg/flake.nix
@@ -4,7 +4,7 @@
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-    glf.url = "github:Gaming-Linux-FR/GLF-OS/main";
+    glf.url = "github:Gaming-Linux-FR/GLF-OS/sebanc-PR";
   };
 
   outputs =

--- a/modules/default/environment.nix
+++ b/modules/default/environment.nix
@@ -35,7 +35,6 @@ in
     };
     environment = {
       etc = {
-         "skel/.background-image".source = ../../assets/wallpaper/white.jpg;
          "wallpapers/glf/white.jpg".source = ../../assets/wallpaper/white.jpg;
          "wallpapers/glf/dark.jpg".source = ../../assets/wallpaper/dark.jpg;
       };

--- a/modules/default/environments/mate.nix
+++ b/modules/default/environments/mate.nix
@@ -13,6 +13,7 @@
     # Activation de Mate
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     services = {
+      blueman.enable = true;
       displayManager.defaultSession = "mate";
       power-profiles-daemon.enable = true;
       xserver = {
@@ -54,24 +55,31 @@
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     # Paramètres Mate
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    programs.dconf = {
-      enable = true;
-      profiles.user.databases = [
-        {
-          settings = {
-            "org/mate/desktop/interface" = {
-              gtk-theme = "adw-gtk3";
-              icon-theme = "Tela-circle";
-            };
+    programs = {
+      nm-applet.enable = true;
+      dconf = {
+        enable = true;
+        profiles.user.databases = [
+          {
+            settings = {
+              "org/mate/desktop/interface" = {
+                gtk-theme = "adw-gtk3";
+                icon-theme = "Tela-circle-light";
+              };
 
-            "org/mate/desktop/background" = {
-              color-shading-type = "solid";
-              picture-options = "zoom";
-              picture-filename = "file:///etc/wallpapers/glf/white.jpg";
+              "org/mate/marco/general" = {
+                theme = "Graphite";
+              };
+
+              "org/mate/desktop/background" = {
+                color-shading-type = "solid";
+                picture-options = "zoom";
+                picture-filename = "file:///etc/wallpapers/glf/white.jpg";
+              };
             };
-          };
-        }
-      ];
+          }
+        ];
+      };
     };
   };
 

--- a/modules/default/environments/plasma.nix
+++ b/modules/default/environments/plasma.nix
@@ -25,7 +25,7 @@
 
     xdg.portal = {
       enable = true;
-      extraPortals = [ pkgs.xdg-desktop-portal-kde ];
+      extraPortals = [ pkgs.kdePackages.xdg-desktop-portal-kde ];
       xdgOpenUsePortal = true;
     };
 
@@ -40,11 +40,11 @@
     programs.kdeconnect.enable = true;
 
     environment = {
-      systemPackages = with pkgs; [
-        writeTextDir "share/sddm/themes/breeze/theme.conf.user" ''
+      systemPackages = [
+        (pkgs.writeTextDir "share/sddm/themes/breeze/theme.conf.user" ''
           [General]
-          background = ${config.environment.etc."wallpapers/glf/white.jpg".source}
-        ''
+          background=/etc/wallpapers/glf/white.jpg
+        '')
       ];
     };
   };

--- a/modules/default/environments/xfce.nix
+++ b/modules/default/environments/xfce.nix
@@ -13,6 +13,7 @@
     # Activation de Xfce
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     services = {
+      blueman.enable = true;
       displayManager.defaultSession = "xfce";
       xserver = {
         displayManager.lightdm.enable = true;

--- a/patches/calamares-nixos-extensions/modules/nixos/main.py
+++ b/patches/calamares-nixos-extensions/modules/nixos/main.py
@@ -40,7 +40,7 @@ cfghead = """{ inputs, config, pkgs, lib, ... }:
 
 cfg_nvidia_opensource = """  glf.nvidia_config = {
     enable = true;
-    version = "opensource";
+    type = "opensource";
     laptop = @@has_laptop@@;
 @@prime_busids@@  };
 
@@ -48,7 +48,7 @@ cfg_nvidia_opensource = """  glf.nvidia_config = {
 
 cfg_nvidia_proprietary = """  glf.nvidia_config = {
     enable = true;
-    version = "proprietary";
+    type = "proprietary";
     laptop = @@has_laptop@@;
 @@prime_busids@@  };
 
@@ -94,6 +94,11 @@ cfgnetwork = """  networking.hostName = "GLF-OS"; # Define your hostname.
 
 cfgnetworkmanager = """  # Enable networking
   networking.networkmanager.enable = true;
+
+"""
+
+cfgbluetooth = """  # Enable bluetooth
+  hardware.bluetooth.enable = true;
 
 """
 
@@ -235,7 +240,7 @@ def convert_to_pci_format(address):
 
 ## Get the current nvidia specialisation
 def get_nvidia_specialisation():
-    result = subprocess.run(['cat /run/booted-system/nixos-version'], stdout=subprocess.PIPE, text=True)
+    result = subprocess.run(['cat', '/run/booted-system/nixos-version'], stdout=subprocess.PIPE, text=True)
     if result is None:
         specialisation = ""
     else:
@@ -461,6 +466,7 @@ def run():
     # Network
     cfg += cfgnetwork
     cfg += cfgnetworkmanager
+    cfg += cfgbluetooth
 
     # Hostname
     if gs.value("hostname") is None:


### PR DESCRIPTION
Bonjour @camini ,

Suite à notre discussion sur le PR #228, je te propose le PR ci-dessous qui active le bluetooth sur les DE autres que Gnome (Gnome le fait par défaut), améliore le rendu de certains DE et corrige de légers bugs.
En complément de la vm, j'ai aussi testé sur un Laptop avec CPU / APU AMD.

Concernant le problème de boot que tu as rencontré, j'ai lancé la construction d'un iso lorsque tu as remonté le problème et il n'a également pas fonctionné chez moi (en raison d'un problème de montage de l'image squashfs qui n'est a priori pas lié à la configuration) et ce problème s'est résolu de lui même lorsque j'ai reconstruit l'image aujourd'hui.

Est-ce que tu pourrais tester cette nouvelle version quand tu as le temps ?

Merci !