### PR TITLE
Fix : no numlock on gdm

### DIFF
--- a/modules/default/gnome.nix
+++ b/modules/default/gnome.nix
@@ -30,6 +30,8 @@
           extraGSettingsOverrides = ''
               [org.gnome.mutter]
             experimental-features=['scale-monitor-framebuffer']
+              [org.gnome.settings-daemon.peripherals]
+            numlock-state=['on']
           '';
         };
       };


### PR DESCRIPTION
> Fr£d — 31 mars 2025 à 20:51
> Le pavé numérique n'est pas actif sur le GDM, après oui.
> Je sais pas si ça peut être corrigé mais je le signale.
