### PR TITLE
feat: add glf branding

### DIFF
--- a/modules/default/branding.nix
+++ b/modules/default/branding.nix
@@ -1,0 +1,16 @@
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
+
+let
+  glfos-branding = pkgs.callPackage ../../pkgs/glfos-branding {};
+in
+
+{
+  environment.systemPackages = with pkgs; [
+      glfos-branding
+  ];
+}

--- a/modules/default/default.nix
+++ b/modules/default/default.nix
@@ -4,6 +4,7 @@
     ./debug.nix
     ./aliases.nix
     ./boot.nix
+    ./branding.nix
     ./firefox.nix
     ./fstrim.nix
     ./gaming.nix

--- a/modules/default/version.nix
+++ b/modules/default/version.nix
@@ -26,7 +26,7 @@ let
     VERSION_ID = cfg.release;
     BUILD_ID = cfg.version;
     PRETTY_NAME = "${DISTRO_NAME} ${cfg.release} (${cfg.codeName})";
-    # LOGO = "glfos-logo"; [FIXME]
+    LOGO = "glfos-logo";
     # HOME_URL = "https://glfos.org"; [FIXME]
     DOCUMENTATION_URL = "";
     SUPPORT_URL = "";

--- a/pkgs/glfos-branding/default.nix
+++ b/pkgs/glfos-branding/default.nix
@@ -1,0 +1,43 @@
+{ 
+  lib,
+  stdenvNoCC, 
+  substituteAll, 
+  writeScriptBin, 
+  fetchFromGitHub, 
+  makeWrapper, 
+  fastfetch, 
+  coreutils, 
+  gawk,
+  bash, 
+  glfIcon ? "GLF"  # ### Use GLF icon or GLFos icon (to change icon) (How to create an overlay with this expression ?)
+}:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "glfos-branding";
+  version = "git-${builtins.substring 0 7 src.rev}"; ### To update version number
+
+  src = fetchFromGitHub {
+    owner = "Gaming-Linux-FR";
+    repo = pname;
+    rev = "59d8f62bc0abca7824266c8ad02b86f2e04101d4";
+    sha256 = "sha256-COSP7jDZLDy1603T76LzKclkgSX5MnJWayANlXZyaIM=";
+  };
+
+  buildInputs = [ bash coreutils ];
+
+  installPhase = ''
+    # Logo
+
+    for SIZE in 16 32 48 64 128 256; do
+      mkdir -p $out/share/icons/hicolor/''${SIZE}x''${SIZE}/emblems
+      cp $src/images/os_logo/logo-$SIZE.png $out/share/icons/hicolor/''${SIZE}x''${SIZE}/emblems/glfos-logo.png
+    done
+  '';
+  
+  meta = {
+    description = "GLF-OS branding";
+    homepage = "https://github.com/Gaming-Linux-FR/glfos-branding";
+    license = lib.licenses.agpl3Plus;
+  };
+
+}


### PR DESCRIPTION
- Changes the gnome-control-center logo to the GLF-OS one.
- Will investigate on the GDM login screen.

Special dedication to @camini :smile: 