### PR TITLE
chore: update nix disks to version `1.2.2` [stable]

### DIFF
--- a/pkgs/nix-disk-manager/default.nix
+++ b/pkgs/nix-disk-manager/default.nix
@@ -25,13 +25,13 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "nix-disk-manager";
-  version = "1.2.0";
+  version = "1.2.2";
 
   src = fetchFromGitHub {
     owner = "Gaming-Linux-FR";
     repo = "nix-disk-manager";
-    rev = "1.2.0";
-    sha256 = "sha256-4UG9NwdRxtW3NJ4xjqcbpwLaz0dyq1AeXa6XBUAPQXY=";
+    rev = "1.2.2";
+    sha256 = "sha256-NLi1dnTrwixSO07DVucdrEZJZBRpNCT8TxlOGjxSKY0=";
   };
 
   format = "other";


### PR DESCRIPTION
Fixes the blkid bug when the partition doesn't have any type.