### PR TITLE
Update environment.nix

### DIFF
--- a/modules/default/environment.nix
+++ b/modules/default/environment.nix
@@ -42,4 +42,8 @@ with lib;
     };
   };
 
+  # Utilise l'horloge au temps local plutôt qu'UTC pour éviter les différences de temps en dual boot Windows/GLFOS
+  time = {
+    hardwareClockInLocalTime = true;
+  };
 }


### PR DESCRIPTION
Configuration pour utiliser l'horloge au temps local plutôt qu'UTC pour éviter les différences de temps en dual boot Windows/GLFOS

  time = {
    hardwareClockInLocalTime = true;
  };