### PR TITLE
Correctif pour l'autologin qui ne fonctionne pas sur beta

### DIFF
--- a/patches/calamares-nixos-extensions/modules/nixos/main.py
+++ b/patches/calamares-nixos-extensions/modules/nixos/main.py
@@ -545,8 +545,8 @@ def run():
         catenate(variables, "groups", (" ").join(['"' + s + '"' for s in groups]))
         if (
             gs.value("autoLoginUser") is not None
-            and gs.value("packagechooser_packagechooser") is not None
-            and gs.value("packagechooser_packagechooser") != ""
+            and gs.value("packagechooser_environment") is not None
+            and gs.value("packagechooser_environment") != ""
         ):
             cfg += cfgautologin
         elif gs.value("autoLoginUser") is not None:


### PR DESCRIPTION
Bonjour à tous,

Suite à la revue des menus packagechooser dans calamares (split en 2 pour les choix de l'environnement et de l'édition), le code relatif à l'autologin n'est plus ajouté dans le fichier configuration.nix.

Ce PR met à jour le nom des variables afin de corriger l'autologin.