### PR TITLE
Update gaming.nix

### DIFF
--- a/modules/default/gaming.nix
+++ b/modules/default/gaming.nix
@@ -22,14 +22,14 @@ in
   config = lib.mkIf config.glf.gaming.enable { # Use 'lib.mkIf' here
 
     environment.systemPackages = with pkgs-unstable; [ # Utiliser pkgs-unstable
-      glxinfo      
+      glxinfo # Show hardware information     
       heroic # Native GOG, Epic, and Amazon Games Launcher for Linux, Windows and Mac
       joystickwake # Joystick-aware screen waker
       linuxKernel.packages.linux_libre.hid-tmff2
       ludusavi # Backup tool for PC game saves
       lutris # Open Source gaming platform for GNU/Linux
       mangohud # Vulkan and OpenGL overlay for monitoring FPS, temperatures, CPU/GPU load and more
-      mesa
+      mesa #Ensure last mesa stable on GLF OS
       oversteer # Steering Wheel Manager for Linux
       protonup-ng # CLI program and API to automate the installation and update of GloriousEggroll's Proton-GE
       protonup-qt # Install and manage Proton-GE and Luxtorpeda for Steam and Wine-GE for Lutris with this graphical user interface

--- a/modules/default/gaming.nix
+++ b/modules/default/gaming.nix
@@ -22,16 +22,20 @@ in
   config = lib.mkIf config.glf.gaming.enable { # Use 'lib.mkIf' here
 
     environment.systemPackages = with pkgs-unstable; [ # Utiliser pkgs-unstable
-      heroic
-      lutris
-      mangohud
-      wineWowPackages.staging
-      winetricks
-      joystickwake
-      oversteer
+      glxinfo      
+      heroic # Native GOG, Epic, and Amazon Games Launcher for Linux, Windows and Mac
+      joystickwake # Joystick-aware screen waker
       linuxKernel.packages.linux_libre.hid-tmff2
+      ludusavi # Backup tool for PC game saves
+      lutris # Open Source gaming platform for GNU/Linux
+      mangohud # Vulkan and OpenGL overlay for monitoring FPS, temperatures, CPU/GPU load and more
       mesa
-      glxinfo
+      oversteer # Steering Wheel Manager for Linux
+      protonup-ng # CLI program and API to automate the installation and update of GloriousEggroll's Proton-GE
+      protonup-qt # Install and manage Proton-GE and Luxtorpeda for Steam and Wine-GE for Lutris with this graphical user interface
+      umu-launcher # Unified launcher for Windows games on Linux using the Steam Linux Runtime and Tools
+      wineWowPackages.staging # Open Source implementation of the Windows API on top of X, OpenGL, and Unix (with staging patches)
+      winetricks # Script to install DLLs needed to work around problems in Wine
     ];
 
     environment.sessionVariables = {


### PR DESCRIPTION
Added some extra gaming related packages. For example: my experience tells me that umu-launcher is required for running Clair Obscur - Expedition 33 via Heroic Games Launcher.