### PR TITLE
Added libraries to Lutris for aagl

### DIFF
--- a/modules/default/gaming.nix
+++ b/modules/default/gaming.nix
@@ -23,7 +23,12 @@ in
 
     environment.systemPackages = with pkgs-unstable; [ # Utiliser pkgs-unstable
       heroic
-      lutris
+
+      # Lutris Config with additional libraries
+      (lutris.override {
+        extraLibraries = p: [ p.libadwaita p.gtk4 ];
+      })
+      
       mangohud
       wineWowPackages.staging
       winetricks


### PR DESCRIPTION
Ajout des librairies libadwaita et gtk pour Lutris afin de faire fonctionner les jeux Hoyoverse (uniquement Honkai Star Rail testé et fonctionnel, les autres je ne sais pas). Sans celles-ci, impossible de lancé Honkai. Etant donné qu'il s'agit d'un jeu plutôt joué, j'ai pensé que cet ajout pouvait être intéressant.

Aussi, c'est ma première contribution à un projet donc si j'ai mal fait quelque chose dites le moi :) La documentation parlait d'une branche dev mais elle ne semble plus exister, donc j'ai supposé qu'omnislash serait la bonne.