### PR TITLE
Adding opentabletdriver

### DIFF
--- a/modules/default/gaming.nix
+++ b/modules/default/gaming.nix
@@ -58,6 +58,7 @@ in
     hardware.steam-hardware.enable = true;
     hardware.xone.enable = true;
     hardware.xpadneo.enable = true;
+    hardware.opentabletdriver.enable = true;
     programs.steam.gamescopeSession.enable = true;
     
 programs.gamescope = {


### PR DESCRIPTION
Utile de pouvoir utiliser une tablette graphique pour jouer à OSU par exemple.