### PR TITLE
system.nix: add nix-ld option

### DIFF
--- a/modules/default/system.nix
+++ b/modules/default/system.nix
@@ -58,6 +58,8 @@
         auto-optimise-store = true;
       };
     };
+    
+    programs.nix-ld.enable = true;
 
   };
 


### PR DESCRIPTION
Cette option permet de rendre utilisable des logiciels non patché (ni construit) par nix/NixOS
