### PR TITLE
nix-disk-manager: update to 1.2.5

### DIFF
--- a/pkgs/nix-disk-manager/default.nix
+++ b/pkgs/nix-disk-manager/default.nix
@@ -25,13 +25,13 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "nix-disk-manager";
-  version = "1.2.3";
+  version = "1.2.4";
 
   src = fetchFromGitHub {
     owner = "Gaming-Linux-FR";
     repo = "nix-disk-manager";
     rev = version;
-    sha256 = "sha256-k40ppm7jg9imi0Kd0lX4uzA/VTm4fy9hKeD/57keREI=";
+    sha256 = "sha256-IfQALYbMZbhKHYWjYtPSIqIUPNBXUldSg6FwYzMWsyk=";
   };
 
   format = "other";

--- a/pkgs/nix-disk-manager/default.nix
+++ b/pkgs/nix-disk-manager/default.nix
@@ -25,13 +25,13 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "nix-disk-manager";
-  version = "1.2.4";
+  version = "1.2.5";
 
   src = fetchFromGitHub {
     owner = "Gaming-Linux-FR";
     repo = "nix-disk-manager";
     rev = version;
-    sha256 = "sha256-IfQALYbMZbhKHYWjYtPSIqIUPNBXUldSg6FwYzMWsyk=";
+    sha256 = "sha256-s2GzGMaiN/avtwlsIqIDrNrsLCwU+/QUhirVQnETX6A=";
   };
 
   format = "other";


### PR DESCRIPTION
Should fix bugs related to partitions without UUID