### PR TITLE
GLFfetch: add symlink to make accessible 'assets' available in profile (with 'out' output)

### DIFF
--- a/pkgs/GLFfetch/default.nix
+++ b/pkgs/GLFfetch/default.nix
@@ -84,6 +84,9 @@ stdenvNoCC.mkDerivation rec {
     mv $assets/share/${pname}/LICENSE $out/share/doc/${pname}/
     mv $assets/share/${pname}/README.md $out/share/doc/${pname}/
 
+    ### Symlink "assets" output to "out" (to make them accessible to profile that GLFfetch is installed)
+    ln -s $assets/share/${pname} $out/share/${pname}
+
     ${lib.optionalString (glfIcon == "GLFos") ''
       ### Link logo from nix store
       ln -s ${./logo.png} $assets/share/${pname}/${glfIcon}.png


### PR DESCRIPTION
Un changement qui rend disponible la sortie "assets" (avec tout les scripts et la conf de GLFfetch) dans le profile dans lequel est installé GLFfetch