### PR TITLE
Firefox - Installer la traduction française uniquement si la locale sélectionnée est "fr"

### DIFF
--- a/modules/default/firefox.nix
+++ b/modules/default/firefox.nix
@@ -13,14 +13,14 @@
     programs.firefox = {
       enable = true;
       wrapperConfig.pipewireSupport = true;
-      languagePacks = [
+      languagePacks = if (config.i18n.defaultLocale == "fr_FR.UTF-8") then [
         "fr"
         "en-US"
-      ];
-      preferences = {
+      ] else [ ];
+      preferences = if (config.i18n.defaultLocale == "fr_FR.UTF-8") then {
         "intl.accept_languages" = "fr-fr,en-us,en";
         "intl.locale.requested" = "fr,en-US";
-      };
+      } else { };
     };
 
   };


### PR DESCRIPTION
Hello Cammi,

Suite à notre conversation ce matin, ce PR permet d'installer la traduction française de Firefox uniquement si la locale principale est "fr".

Bonne soirée.