### PR TITLE
Update boot.nix : Add EFI BOOTLOADER-ID to GLF-OS

### DIFF
--- a/modules/default/boot.nix
+++ b/modules/default/boot.nix
@@ -39,6 +39,7 @@ in
       ACTION=="add|change", SUBSYSTEM=="block", ATTR{queue/scheduler}="bfq"
     '';
 
+    boot.loader.grub.efiBootloaderId = "GLF-OS"
     boot.loader.grub.splashImage = ../../assets/wallpaper/dark.jpg;
     boot.loader.grub.default = "saved";
     boot = {


### PR DESCRIPTION
Allow viewing GLFOS inside EFI than seeing "UEFI OS" default name