### PR TITLE
Ajout de l'icone manquant welcome-screen dans le dock

### DIFF
--- a/pkgs/glfos-welcome-screen/default.nix
+++ b/pkgs/glfos-welcome-screen/default.nix
@@ -79,7 +79,7 @@ stdenvNoCC.mkDerivation rec {
       --set LD_LIBRARY_PATH "${lib.makeLibraryPath buildInputs}:$out/lib"
 
       mkdir -p $out/share/icons
-      cp assets/images/512x512.png $out/share/icons/glfos-welcome-screen.png
+      cp data/flutter_assets/assets/images/512x512.png $out/share/icons/glfos-welcome-screen.png
 
       mkdir -p $out/etc/xdg/autostart
       cp ${desktopFile}/share/applications/glfos-welcome-screen.desktop $out/etc/xdg/autostart/glfos-welcome-screen.desktop

--- a/pkgs/glfos-welcome-screen/default.nix
+++ b/pkgs/glfos-welcome-screen/default.nix
@@ -77,7 +77,10 @@ stdenvNoCC.mkDerivation rec {
 
       makeWrapper $out/glfos_welcome_screen $out/bin/glfos-welcome-screen \
       --set LD_LIBRARY_PATH "${lib.makeLibraryPath buildInputs}:$out/lib"
-  
+
+      mkdir -p $out/share/icons
+      cp assets/images/512x512.png $out/share/icons/glfos-welcome-screen.png
+
       mkdir -p $out/etc/xdg/autostart
       cp ${desktopFile}/share/applications/glfos-welcome-screen.desktop $out/etc/xdg/autostart/glfos-welcome-screen.desktop
       mkdir -p $out/share/applications


### PR DESCRIPTION
Il manquait la commande de copie de l'icone
Avec cette modif on a bien dans le dock et dans applications

<img width="839" height="764" alt="image" src="https://github.com/user-attachments/assets/544e4cf3-455f-405e-8513-8a8be8773f14" />
<img width="1164" height="830" alt="image" src="https://github.com/user-attachments/assets/00e2846c-c57f-488e-853a-43889007faaf" />
